### PR TITLE
Changed to use working directory instead of executable's directory as CHANGELOG.md location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.2.2] - 2025-04-27
+
+### Fixed
+
+- Fixed to look for CHANGELOG.md from a working directory instead of executable's directory 
+
 ## [0.2.1] - 2025-04-27
 
 ### Fixed

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/hkionline/verso"
 )
@@ -34,15 +33,11 @@ func New() (*app, error) {
 func (a *app) ReadChangelog() {
 	// TODO: Add logic to read CHANGELOG from a specific path. For now, current working directory is used.
 
-	execPath, err := os.Executable()
+	execPath, err := os.Getwd()
+
 	if err != nil {
-		log.Fatalf("failed to get path for current executable: %v\n", err)
+		log.Fatalf("failed to get path for current working directory: %v\n", err)
 	}
-
-	splitPath := strings.Split(execPath, "/")
-	splitPath = splitPath[0 : len(splitPath)-1] // Remove the last index, which is the executable name
-
-	execPath = strings.Join(splitPath, "/")
 
 	a.changelog, err = verso.Parse(execPath + "/CHANGELOG.md")
 


### PR DESCRIPTION
Changed to use workding directory instead of executable's directory as CHANGELOG.md location. When merged, this PR closes issue #21.